### PR TITLE
🐛 Fix fluid typing issue with query parameters

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -17,6 +17,8 @@ import (
 	"github.com/sudoblockio/icon-go-api/global"
 )
 
+const queryTag = "query"
+
 // @title Icon Go API
 // @version 2.0
 // @description The icon tracker API
@@ -48,6 +50,12 @@ func Start() *fiber.App {
 			return strings.Contains(c.Path(), "/docs/")
 		},
 	}))
+
+	// Enforces strict typing for query parameters
+	fiber.SetParserDecoder(fiber.ParserConfig{
+		SetAliasTag:       queryTag,
+		IgnoreUnknownKeys: false,
+	})
 
 	// Swagger docs
 	app.Get(config.Config.RestPrefix+"/docs/*", swagger.HandlerDefault)


### PR DESCRIPTION
Description:
fiber query by default ignoring the keys that are not recognized, and providing default values for any keys that are missing in the parsed struct to make the query strict to allow only if valid arguments